### PR TITLE
Testing links

### DIFF
--- a/linked-file_2.md
+++ b/linked-file_2.md
@@ -1,0 +1,1 @@
+Just testing the `core.symlinks = true` setting on both the code host and SG

--- a/linked-file_3.md
+++ b/linked-file_3.md
@@ -1,0 +1,1 @@
+Just testing the `core.symlinks = false` setting on both the code host and SG

--- a/single-symlink_2
+++ b/single-symlink_2
@@ -1,0 +1,1 @@
+linked-file_2.md

--- a/single-symlink_3
+++ b/single-symlink_3
@@ -1,0 +1,1 @@
+linked-file_3.md


### PR DESCRIPTION
Was testing to see if setting the core.symlinks option in git changed the behavior on the github side and it doesn't look to. Still seems to walk down the link tree either way. Interestingly enough ... now I am very interested in what behavior this changes though.

(I did pushes with it set to both true and false)

https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresymlinks